### PR TITLE
Use a correct version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name = "django-postgres-fuzzycount",
-    version = "0.1.6",
+    version = "0.2.1",
     author = "Stephen McDonald",
     author_email = "stephen.mc@gmail.com",
     description = ("A Django model manager providing fast / fuzzy counts "


### PR DESCRIPTION
Using an older version that current pypi on the master on git makes pip very confused, and makes it uses older code if it can. This fixes this by introducing 0.2.1 for the master version. Please merge and release a new version to pypi?
