### PR TITLE
Drop support for Django < 1.9

### DIFF
--- a/fuzzycount.py
+++ b/fuzzycount.py
@@ -1,13 +1,6 @@
-from distutils.version import LooseVersion
-
 from django.conf import settings
 from django.db import connections
 from django.db.models import QuerySet, Manager
-import django
-
-
-DJANGO_VERSION_GTE_19 = LooseVersion(django.get_version()) \
-                        >= LooseVersion('1.9')
 
 
 class FuzzyCountQuerySet(QuerySet):
@@ -16,15 +9,7 @@ class FuzzyCountQuerySet(QuerySet):
         engine = settings.DATABASES[self.db]["ENGINE"].split(".")[-1]
         is_postgres = engine.startswith(postgres_engines)
 
-        # In Django 1.9 the query.having property was removed and the
-        # query.where property will be truthy if either where or having
-        # clauses are present. In earlier versions these were two separate
-        # properties query.where and query.having
-        if DJANGO_VERSION_GTE_19:
-            is_filtered = self.query.where
-        else:
-            is_filtered = self.query.where or self.query.having
-        if not is_postgres or is_filtered:
+        if not is_postgres or self.query.where:
             return super(FuzzyCountQuerySet, self).count()
         cursor = connections[self.db].cursor()
         cursor.execute("SELECT reltuples FROM pg_class "

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     py_modules=["fuzzycount",],
     install_requires = [
         "sphinx-me >= 0.1.2",
-        "django >= 1.7",
+        "django >= 1.9",
     ],
     classifiers = [
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Django 1.9 has not been supported since 2017 and dropping support makes it easier to get rid of these deprecation warnings:
```
DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  DJANGO_VERSION_GTE_19 = LooseVersion(django.get_version()) \
DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  >= LooseVersion('1.9')
```